### PR TITLE
Update berkshelf

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,6 +1,5 @@
-site :opscode
+source 'https://api.berkshelf.com'
 
 metadata
 
-cookbook 'apt', '~> 2.0'
 cookbook 'loggly-rsyslog_test', path: 'test/cookbooks/loggly-rsyslog_test'

--- a/Berksfile
+++ b/Berksfile
@@ -2,4 +2,6 @@ source 'https://api.berkshelf.com'
 
 metadata
 
-cookbook 'loggly-rsyslog_test', path: 'test/cookbooks/loggly-rsyslog_test'
+group :test do
+  cookbook 'loggly-rsyslog_test', path: 'test/cookbooks/loggly-rsyslog_test'
+end

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'rake', '~> 10.2'
-gem 'berkshelf',  '~> 2.0'
+gem 'berkshelf',  '~> 3'
 gem 'foodcritic', '~> 3.0'
 gem 'rubocop'
 gem 'chefspec',   '~> 3.1'

--- a/metadata.rb
+++ b/metadata.rb
@@ -8,5 +8,5 @@ version          '2.1.0'
 
 supports 'ubuntu', '>= 12.04'
 
+depends "apt", "~> 2.0"
 depends "rsyslog", "~> 1.5.0"
-


### PR DESCRIPTION
- Updated Berkshelf to ~> 3
- Updated Berksfile to use new v3 source
- Moved cookbook dependencies from Berksfile into metadata
- Put test cookbook into a 'test' group, so it can be excluded from upload
